### PR TITLE
Improve Jumping

### DIFF
--- a/assets/js/game/camera.js
+++ b/assets/js/game/camera.js
@@ -199,10 +199,11 @@ document.addEventListener("keydown", e => {
       right = true;
       break;
     case "Space":
-      vup = true;
+      if (cam.gravityEnabled) cam.jump();
+      else vup = true;
       break;
     case "ShiftLeft":
-      vdown = true;
+      if (!cam.gravityEnabled) vdown = true;
       break;
     case "Backquote":
       if (!supportsPointerLock()) break;

--- a/assets/js/game/camera.js
+++ b/assets/js/game/camera.js
@@ -164,7 +164,7 @@ if(isTouchDevice()) {
   
   // shift
   $("#ui > #gui > #v-movement #shift")
-  .addEventListener("pointerup", e => {
+  .addEventListener("touchstart", e => {
     if(!cam.gravityEnabled) {
       cam.enableGravity();
     } else {

--- a/assets/js/game/camera.js
+++ b/assets/js/game/camera.js
@@ -170,8 +170,19 @@ if(isTouchDevice()) {
     const jumpPressTime = Date.now();
     if (jumpPressTime - lastJumpPressTime <= 250) {
       // Double jump
-      if (cam.gravityEnabled) cam.disableGravity();
-      else cam.enableGravity();
+      if (cam.gravityEnabled) {
+        cam.disableGravity();
+        $("#v-movement > #up").style.visibility = "visible";
+        $("#v-movement > #down").style.visibility = "visible";
+        $("#v-movement > #shift").src = "/assets/images/game/circle.png";
+      } else {
+        cam.enableGravity();
+        $("#v-movement > #up").style.visibility = "hidden";
+        $("#v-movement > #down").style.visibility = "hidden";
+        $("#v-movement > #shift").src = "/assets/images/game/small_arrow.png";
+        vup = false;
+        vdown = false;
+      }
 
       lastJumpPressTime = 0;
     } else {
@@ -250,8 +261,19 @@ document.addEventListener("keydown", e => {
     const keypressTime = Date.now();
     if (keypressTime - lastKeypressTime <= 250) {
       // Double space bar pressed
-      if (cam.gravityEnabled) cam.disableGravity();
-      else cam.enableGravity();
+      if (cam.gravityEnabled) {
+        cam.disableGravity();
+        $("#v-movement > #up").style.visibility = "visible";
+        $("#v-movement > #down").style.visibility = "visible";
+        $("#v-movement > #shift").src = "/assets/images/game/circle.png";
+      } else {
+        cam.enableGravity();
+        $("#v-movement > #up").style.visibility = "hidden";
+        $("#v-movement > #down").style.visibility = "hidden";
+        $("#v-movement > #shift").src = "/assets/images/game/small_arrow.png";
+        vup = false;
+        vdown = false;
+      }
 
       lastKeypressTime = 0;
     } else {

--- a/assets/js/game/camera.js
+++ b/assets/js/game/camera.js
@@ -162,13 +162,20 @@ if(isTouchDevice()) {
   $("#ui > #gui > #v-movement")
   .addEventListener("gesturestart", e => e.preventDefault());
   
+  var lastJumpPressTime = 0;
   // shift
   $("#ui > #gui > #v-movement #shift")
   .addEventListener("touchstart", e => {
-    if(!cam.gravityEnabled) {
-      cam.enableGravity();
+    if (cam.gravityEnabled) cam.jump();
+    const jumpPressTime = Date.now();
+    if (jumpPressTime - lastJumpPressTime <= 250) {
+      // Double jump
+      if (cam.gravityEnabled) cam.disableGravity();
+      else cam.enableGravity();
+
+      lastJumpPressTime = 0;
     } else {
-      cam.jump();
+      lastJumpPressTime = jumpPressTime;
     }
   });
 }
@@ -239,10 +246,11 @@ document.addEventListener("keydown", e => {
   if (e.code === "Space") {
     if (keyState) return;
     keyState = true;
-    let keypressTime = Date.now();
+    const keypressTime = Date.now();
     if (keypressTime - lastKeypressTime <= 250) {
       // Double space bar pressed
-      cam.enableGravity();
+      if (cam.gravityEnabled) cam.disableGravity();
+      else cam.enableGravity();
 
       lastKeypressTime = 0;
     } else {

--- a/assets/js/lib/camera.js
+++ b/assets/js/lib/camera.js
@@ -276,6 +276,11 @@ export class PhysicsCamera extends MovementCamera {
     this._gravityLoop.start();
   }
   
+  disableGravity() {
+    this.gravityEnabled = false;
+    this._gravityLoop.stop();
+  }
+  
   _jumpInertia = 0.25;
   _jumpLoop = stopLoop(({stop}) => {
     this.moveAbove(this._jumpInertia);


### PR DESCRIPTION
## Touchscreen Features
- [x] Use "touchstart" instead of "pointerup" to jump on press instead of release
- [x] Hide fly up and down buttons when gravity is enabled
- [x] Change jump button icon
- [x] Make enable gravity button require double tap

## Keyboard Features
- [x] Support jumping by replacing fly up using space bar with jump when gravity is enabled
- [x] Disable flying down using left shift when gravity is enabled

## Both Features
- [x] Re-enable flying when double pressing jump
  - [x] Double press space bar on keyboard
  - [x] Double tap jump on touchscreen